### PR TITLE
bug: 플레이어 점프시에 nullptr 에러

### DIFF
--- a/YamYamEngine/YamYamEngine_SOURCE_static/yaRigidbody.cpp
+++ b/YamYamEngine/YamYamEngine_SOURCE_static/yaRigidbody.cpp
@@ -14,7 +14,7 @@ namespace ya
 	{
 		mLimitedVelocty.x = 200.0f;
 		mLimitedVelocty.y = 1000.0f;
-		mGravity = Vector3(0.0f, 800.0f, 0.0f);
+		mGravity = Vector3(0.0f, 9.8f, 0.0f);
 	}
 
 	Rigidbody::~Rigidbody()
@@ -40,9 +40,14 @@ namespace ya
 		{
 			// 땅위에 있을때
 			Vector3 gravity = mGravity;
-			gravity.normalize();
-			float dot = mVelocity.Dot(gravity);
-			mVelocity -= gravity * dot;
+
+			// 중력 값이 0인 상태에서 정규화를 하면 벡터 값이 nan이 됨
+			if(gravity != Vector3::Zero)
+			{
+				gravity.normalize();
+				float dot = mVelocity.Dot(gravity);
+				mVelocity -= gravity * dot;
+			}
 		}
 		else
 		{

--- a/YamYamEngine/YamYamEngine_Windows/yaPlayScene.cpp
+++ b/YamYamEngine/YamYamEngine_Windows/yaPlayScene.cpp
@@ -43,10 +43,14 @@ namespace ya
 			tr->SetScale(Vector3(1.0f, 1.0f, 1.0f));
 
 			cld1->SetSize(Vector3(1.0f, 1.0f, 1.0f));
+
+			// ** 테스트용으로 플레이어의 중력을 없애놨음. 나중에 풀어야 함!! **
 			rb->SetGravity(Vector3::Zero);
+
 			rb->SetFriction(0.25f);
 
 			AddGameObject(player, LAYER::PLAYER);
+			player->Initialize();
 		}
 
 		GameObject* wall_a = new GameObject();


### PR DESCRIPTION
- 플레이어 내부에서 rigidbody를 저장하는 변수가 있는데, 이 변수가 `Initialize()`에서 초기화됨
- 그러나 플레이어 생성된 후 `Initialize()`가 불리지 않아 nullptr rigidboy에 대해 포인터를 참조함